### PR TITLE
Add a proper DB check

### DIFF
--- a/index.php
+++ b/index.php
@@ -37,8 +37,8 @@ if (isset($argv) && $argv[0]) {
 define('NO_UPGRADE_CHECK', true);
 define('ABORT_AFTER_CONFIG', true);
 
-require('../../../config.php');
-global $DB, $CFG;
+require_once('../../../config.php');
+global $CFG;
 
 $status = "";
 
@@ -58,7 +58,7 @@ function failed($reason) {
 
 $testfile = $CFG->dataroot . "/tool_heartbeat.test";
 $size = file_put_contents($testfile, '1');
-if ($size !== 1){
+if ($size !== 1) {
     failed('sitedata not writable');
 }
 
@@ -79,6 +79,25 @@ if ($sessionhandler) {
         $status .= "session memcache OK<br>\n";
     } catch (Exception $e) {
         failed('sessions memcache');
+    }
+}
+
+// Optionally check database configuration and access (slower).
+if (true) {
+    try {
+        define('ABORT_AFTER_CONFIG_CANCEL', true);
+        require($CFG->dirroot . '/lib/setup.php');
+        global $DB;
+
+        // Try to get the first record from the user table.
+        $user = $DB->get_record_sql('SELECT id FROM {user} WHERE 0 < id ', null, IGNORE_MULTIPLE);
+        if ($user) {
+            $status .= "database OK<br>\n";
+        } else {
+            failed('no users in database');
+        }
+    } catch (Exception $e) {
+        failed('database error');
     }
 }
 


### PR DESCRIPTION
The pre-existing code does not actually check the database because defining ABORT_AFTER_CONFIG stops before setting up the $DB connection. This can lead to a situation where the heartbeat tool returns 200 when Moodle is actually broken (e.g. mysql is not running, so trying to access Moodle will throw a 503).

Understandably, adding in this check slows down the heartbeat tool: in my testing, with database checking enabled, the heartbeat takes approximately 50ms; without database checking enabled, the heartbeat takes <10ms.

I also fixed a slight Moodle coding style warning on line 61.