### PR TITLE
Fixes error: Exception - Call to undefined function mnet_get_hosts().

### DIFF
--- a/croncheck.php
+++ b/croncheck.php
@@ -274,7 +274,7 @@ if ( $maxminsdelay > $options['delayerror'] ) {
 
 // If the Check API from 3.9 exists then call those as well:
 if (class_exists('\core\check\manager')) {
-
+    require_once($CFG->dirroot.'/mnet/lib.php');
     $checks = \core\check\manager::get_checks('status');
     $output = '';
     // Should this check block emit as critical?


### PR DESCRIPTION
Hi,
Moodle version: 4 

To view the error enable Mnet. 

This will resolve the below error:

Exception - Call to undefined function mnet_get_hosts()

More information about this error
Debug info:
Error code: generalexceptionmessage
Stack trace:

    line 2761 of /lib/upgradelib.php: Error thrown
    line 736 of /lib/environmentlib.php: call to check_xmlrpc_usage()
    line 482 of /lib/environmentlib.php: call to environment_custom_checks()
    line 106 of /lib/environmentlib.php: call to environment_check()
    line 70 of /lib/classes/check/environment/environment.php: call to check_moodle_environment()
    line 285 of /admin/tool/heartbeat/croncheck.php: call to core\check\environment\environment->get_result()

Regards,

Sumaiya