### PR TITLE
[#178] Remove ping debugging log

### DIFF
--- a/classes/check/cachecheck.php
+++ b/classes/check/cachecheck.php
@@ -180,11 +180,6 @@ class cachecheck extends check {
             // This should help detect any cache replication delays.
             $readbackvalue = self::get_cache_ping_value($type);
 
-            // Checking if behat site is running.
-            if (!(defined('BEHAT_SITE_RUNNING') && BEHAT_SITE_RUNNING)) {
-                debugging("\nHEARTBEAT doing {$type} ping\n", DEBUG_DEVELOPER);
-            }
-
             if (get_config('tool_heartbeat', 'shouldlogcacheping')) {
                 lib::record_cache_pinged($currentcache, $currentdb, $time, $readbackvalue, $type);
             }


### PR DESCRIPTION
**Changes**
- Removes `debugging` call notifying that a ping was recorded

**Background**
This was added in the initial v1 of the cachecheck code, but later in this commit I added proper detailed logging through the error log https://github.com/catalyst/moodle-tool_heartbeat/commit/ad207a79ab19ae2017c18419fd79fc040b818461#diff-deba58272dc99a02e8d399f41f35387ac5606d84205b2ce8b8502989bc81e811R115 but didn't remove the original debugging not for any reason other than just forgetting. Having this debugging causes lots of issues in unit & behat tests like:

```
Unexpected debugging() call detected.
Debugging: 
HEARTBEAT doing web ping
```

Closes #178 

### Pull request checks
- [y] I have checked the version numbers are correct as per the [README](./README.md#branches)
