### PR TITLE
[#225] Fix Totara compatibility bug with the core get_directory_size …

### DIFF
--- a/classes/check/dirsizes.php
+++ b/classes/check/dirsizes.php
@@ -17,10 +17,9 @@
 /**
  * Dir sizes performance check.
  *
- * @package    tool_heartbeat
- * @copyright  2023 Brendan Heywood <brendan@catalyst-au.net>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- *
+ * @package   tool_heartbeat
+ * @copyright 2023 Brendan Heywood <brendan@catalyst-au.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 namespace tool_heartbeat\check;
@@ -30,9 +29,9 @@ use core\check\result;
 /**
  * Dir sizes performance check.
  *
- * @copyright  2023
- * @author     Brendan Heywood <brendan@catalyst-au.net>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright 2023
+ * @author    Brendan Heywood <brendan@catalyst-au.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class dirsizes extends check {
 
@@ -44,11 +43,10 @@ class dirsizes extends check {
     public function get_result(): result {
         global $CFG;
 
-        $sizedataroot = get_directory_size($CFG->dataroot);
+        $sizedataroot = $this->dirsize('dataroot', true);
         $summary = $sizedataroot;
         $details = "Shared paths:<br>";
         $details .= '$CFG->dataroot = ' . display_size($sizedataroot);
-
         $details .= $this->dirsize('themedir');
         $details .= $this->dirsize('tempdir');
         $details .= $this->dirsize('cachedir');
@@ -61,19 +59,72 @@ class dirsizes extends check {
         return new result(result::INFO, $summary, $details);
     }
     /**
-     * Get a paths sizet
-     * @param string $cfg the path to check
-     * @return string size for a path as html
+     * Get a path's size
+     *
+     * @param  string $cfg the path to check
+     * @param  bool $rawsize return rawsize of directory
+     * @return string $size for a path as html
      */
-    private function dirsize(string $cfg) {
+    private function dirsize(string $cfg, bool $rawsize = false) {
         global $CFG;
         if (!property_exists($CFG, $cfg)) {
             return "<br>\$CFG->$cfg not in use";
         }
         $path = $CFG->{$cfg};
-        $size = get_directory_size($path);
+
+        // If Totara, use Totara-compatible function.
+        if (!empty($CFG->totara_version)) {
+            $size = $this->get_directory_size_totara($path);
+        } else {
+            $size = get_directory_size($path);
+        }
+
+        if ($rawsize) {
+            return $size;
+        }
 
         return "<br>\$CFG->{$cfg} = " . display_size($size);
     }
 
+    /**
+     * Recursively calculate the size of a directory (Totara-compatible).
+     *
+     * This replicates Moodle core's get_directory_size() logic,
+     * but avoids using it directly for Totara compatibility.
+     *
+     * @param  string $dir The directory path to measure
+     * @return int Total size in bytes
+     */
+    private function get_directory_size_totara(string $dir): int {
+        if (!is_dir($dir)) {
+            return 0;
+        }
+
+        $size = 0;
+        if (!$dh = @opendir($dir)) {
+            return 0;
+        }
+
+        while (false !== ($file = readdir($dh))) {
+            // Skip hidden files and CVS dirs.
+            if ($file[0] === '.' || $file === 'CVS') {
+                continue;
+            }
+
+            $fullfile = $dir . '/' . $file;
+
+            if (is_dir($fullfile)) {
+                // Recurse into subdirectory.
+                $size += $this->get_directory_size_totara($fullfile);
+            } else {
+                $filesize = filesize($fullfile);
+                if ($filesize !== false) {
+                    $size += $filesize;
+                }
+            }
+        }
+
+        closedir($dh);
+        return $size;
+    }
 }

--- a/tests/check/dirsizes_totara_test.php
+++ b/tests/check/dirsizes_totara_test.php
@@ -1,0 +1,94 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_heartbeat\check;
+
+use tool_heartbeat\check\dirsizes;
+
+/**
+ * Test class for Totara tool_heartbeat\check\dirsizes
+ *
+ * @package   tool_heartbeat
+ * @author    Alex Damsted <alexdamsted@catalyst-au.net>
+ * @copyright 2025, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @coversDefaultClass \tool_heartbeat\check\dirsizes
+ */
+final class dirsizes_totara_test extends \advanced_testcase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+    }
+
+    /**
+     * Ensure get_directory_size_totara counts file sizes correctly.
+     *
+     * @covers ::get_directory_size_totara
+     */
+    public function test_dirsize_totara_counts_files(): void {
+        global $CFG;
+        $dir = make_request_directory('tool_heartbeat_test1');
+        $CFG->tempdir = $dir;
+
+        // Create two test files with known sizes.
+        file_put_contents($dir . '/file1.txt', str_repeat('a', 100));
+        file_put_contents($dir . '/file2.txt', str_repeat('b', 200));
+        $check = new dirsizes();
+        $size = $this->invokeMethod($check, 'get_directory_size_totara', [$CFG->tempdir]);
+
+        $this->assertEquals(300, $size);
+    }
+
+    /**
+     * Ensure get_directory_size_totara counts nested files in subdirectories.
+     *
+     * @covers ::get_directory_size_totara
+     */
+    public function test_dirsize_totara_counts_nested_files(): void {
+        global $CFG;
+
+        $dir = make_request_directory('tool_heartbeat_test2');
+        $CFG->tempdir = $dir;
+
+        // Create subdirectory with file.
+        $subdir = $dir . '/subdir';
+        check_dir_exists($subdir);
+        file_put_contents($subdir . '/nested.txt', str_repeat('x', 150));
+
+        $check = new dirsizes();
+        $size = $this->invokeMethod($check, 'get_directory_size_totara', [$CFG->tempdir]);
+
+        $this->assertGreaterThanOrEqual(150, $size);
+    }
+
+    /**
+     * Call private methods.
+     *
+     * @param object $object
+     * @param string $method
+     * @param array $args
+     * @return mixed
+     */
+    protected function invokemethod($object, string $method, array $args = []) {
+        $reflection = new \ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($method);
+        $method->setAccessible(true);
+        return $method->invokeArgs($object, $args);
+    }
+}
+


### PR DESCRIPTION
This PR is trying to solve a bug in issue https://github.com/catalyst/moodle-tool_heartbeat/issues/225 where the get_directory_size core Totara/Moodle function throws a fatal exception in Totara sites. Moodle has newer code for the function that would resolve this for Totara but to avoid core hacks this PR does a code fork and adds compatibility for Totara.

**Replication steps:**
1. Access /report/performance/index.php to see the fatal exception.
2. The following condition must pass in get_directory_size:
` if (!empty($CFG->pathtodu) && is_executable(trim($CFG->pathtodu))`
3. The following dirs do not end with a '/' where ever they are set:
` $allowedbasedirs = array(
            $CFG->dataroot,
            $CFG->localcachedir,
            $CFG->tempdir,
            $CFG->cachedir,
            $CFG->dirroot
        );`
