### PR TITLE
Unit tests were not getting output

### DIFF
--- a/classes/checker.php
+++ b/classes/checker.php
@@ -151,6 +151,11 @@ class checker {
      * @return resultmessage
      */
     private static function exception_to_message(string $prefix, Throwable $e): resultmessage {
+        // Errors can be swallowed, make sure phpunit can see them.
+        if (defined('PHPUNIT_TEST') && PHPUNIT_TEST) {
+            throw $e;
+        }
+
         $res = new resultmessage();
         $res->level = resultmessage::LEVEL_WARN;
         $res->title = $prefix . $e->getMessage();


### PR DESCRIPTION
I was having an issue where errors returned by core were not being thrown. E.g., I would run vendor/bin/phpunit admin/tool/heartbeat/tests/checker_test.php and get a unit test failure like:

```
There was 1 failure:

1) tool_heartbeat\checker_test::test_get_check_messages_with_filter
Failed asserting that an array is empty.

/var/www/catalyst-moodle/admin/tool/heartbeat/tests/checker_test.php:60
/var/www/catalyst-moodle/lib/phpunit/classes/advanced_testcase.php:76

--

There was 1 risky test:

1) tool_heartbeat\checker_test::test_get_check_messages
Test code or tested code did not (only) close its own output buffers

/var/www/catalyst-moodle/lib/phpunit/classes/advanced_testcase.php:76

FAILURES!
Tests: 18, Assertions: 19, Failures: 1, Risky: 1.
```

But a php notice was being masked. After applying the commit in this PR, I get the correct output:

```
EE................                                                18 / 18 (100%)

Time: 00:01.993, Memory: 70.50 MB

There were 2 errors:

1) tool_heartbeat\checker_test::test_get_check_messages
Undefined property: stdClass::$converter_plugins_sortorder

/var/www/catalyst-moodle/files/converter/catalytic/lib.php:32
/var/www/catalyst-moodle/lib/classes/check/manager.php:107
/var/www/catalyst-moodle/lib/classes/check/manager.php:56
/var/www/catalyst-moodle/admin/tool/heartbeat/classes/checker.php:78
/var/www/catalyst-moodle/admin/tool/heartbeat/tests/checker_test.php:40
/var/www/catalyst-moodle/lib/phpunit/classes/advanced_testcase.php:76

2) tool_heartbeat\checker_test::test_get_check_messages_with_filter
Undefined property: stdClass::$converter_plugins_sortorder

/var/www/catalyst-moodle/files/converter/catalytic/lib.php:32
/var/www/catalyst-moodle/lib/classes/check/manager.php:107
/var/www/catalyst-moodle/lib/classes/check/manager.php:56
/var/www/catalyst-moodle/admin/tool/heartbeat/classes/checker.php:78
/var/www/catalyst-moodle/admin/tool/heartbeat/tests/checker_test.php:54
/var/www/catalyst-moodle/lib/phpunit/classes/advanced_testcase.php:76

ERRORS!
Tests: 18, Assertions: 16, Errors: 2.
```