### PR TITLE
Issue #247: Ignore scheduled task overdue if plugin component is disabled

### DIFF
--- a/classes/check/scheduledqueue.php
+++ b/classes/check/scheduledqueue.php
@@ -19,6 +19,7 @@ namespace tool_heartbeat\check;
 use action_link;
 use core\check\check;
 use core\check\result;
+use core_plugin_manager;
 use moodle_url;
 
 /**
@@ -43,6 +44,7 @@ class scheduledqueue extends check {
      */
     public function get_result(): result {
         $now = time();
+        $pluginmanager = core_plugin_manager::instance();
 
         // Use the task manager API so that $CFG->scheduled_tasks config overrides
         // (which can force-disable or force-enable tasks) are respected.
@@ -53,6 +55,14 @@ class scheduledqueue extends check {
             if ($task->get_disabled()) {
                 continue;
             }
+
+            // Mirror core task dispatch behaviour: if the component plugin is
+            // disabled, skip this task unless it is explicitly allowed to run.
+            $plugininfo = $pluginmanager->get_plugin_info($task->get_component());
+            if ($plugininfo && $plugininfo->is_enabled() === false && !$task->get_run_if_component_disabled()) {
+                continue;
+            }
+
             $age = $now - $task->get_next_run_time();
             if ($age > 0) {
                 $overdue[] = (object)[

--- a/classes/check/scheduledqueue.php
+++ b/classes/check/scheduledqueue.php
@@ -19,7 +19,6 @@ namespace tool_heartbeat\check;
 use action_link;
 use core\check\check;
 use core\check\result;
-use core_plugin_manager;
 use moodle_url;
 
 /**
@@ -44,7 +43,6 @@ class scheduledqueue extends check {
      */
     public function get_result(): result {
         $now = time();
-        $pluginmanager = core_plugin_manager::instance();
 
         // Use the task manager API so that $CFG->scheduled_tasks config overrides
         // (which can force-disable or force-enable tasks) are respected.
@@ -52,14 +50,7 @@ class scheduledqueue extends check {
 
         $overdue = [];
         foreach ($alltasks as $task) {
-            if ($task->get_disabled()) {
-                continue;
-            }
-
-            // Mirror core task dispatch behaviour: if the component plugin is
-            // disabled, skip this task unless it is explicitly allowed to run.
-            $plugininfo = $pluginmanager->get_plugin_info($task->get_component());
-            if ($plugininfo && $plugininfo->is_enabled() === false && !$task->get_run_if_component_disabled()) {
+            if (!$task->is_enabled()) {
                 continue;
             }
 


### PR DESCRIPTION
This PR fixes false-positive Scheduled task queue alerts in Heartbeat by excluding tasks that should not run.

The check now ignores:

- Tasks that are disabled.
- Tasks whose component plugin is disabled, unless the task is explicitly allowed to run when the component is disabled.

This aligns the Heartbeat check behavior with Moodle core task-dispatch behavior and prevents CRITICAL/WARNING noise for intentionally disabled functionality.

**Problem**

Heartbeat was reporting overdue scheduled tasks as CRITICAL even when those tasks belonged to disabled plugins (or were otherwise not meant to execute).
This created misleading alerts in the logs.


**How To Test**
1. Baseline: enabled overdue task still alerts
- Ensure an enabled scheduled task has nextruntime in the past.
- Run Heartbeat check endpoint.
- Confirm the task appears in Scheduled task queue output and status escalates according to thresholds.

Expected:
- Overdue enabled task is still reported.

2. Disabled task is ignored
- Disable a scheduled task in Scheduled tasks admin.
- Set its nextruntime in the past (or pick one already overdue).
- Run Heartbeat check endpoint.

Expected:
- That disabled task is not included in Scheduled task queue overdue details.
- It does not contribute to WARNING/CRITICAL calculation.

3. Disabled plugin task is ignored
- Disable a plugin that provides scheduled tasks.
- Confirm its task record is overdue.
- Run Heartbeat check endpoint.

Expected:
- Tasks from that disabled plugin are not counted as overdue by this check.
- No false CRITICAL caused solely by those tasks.

5. Regression: normal checks still work
- Leave at least one enabled runnable task overdue beyond error threshold.
- Run Heartbeat check endpoint.

Expected:
- Check still returns WARNING/CRITICAL as before for genuinely overdue runnable tasks.
### Pull request checks
- [ ] I have checked the version numbers are correct as per the [README](./README.md#branches)
