### PR TITLE
Expose hard and soft main mode #251

### DIFF
--- a/croncheck.php
+++ b/croncheck.php
@@ -41,7 +41,50 @@ if ($iscli) {
 }
 
 $dirroot = __DIR__ . '/../../../';
+
+if (substr($_SERVER['SCRIPT_FILENAME'], -42) == '/public/admin/tool/heartbeat/croncheck.php') {
+    // We are in Moodle 5.2 under the public/ sub path.
+    $dirroot = __DIR__ . '/../../../../';
+}
+
+/**
+ * Checks if the command line maintenance mode has been enabled. Skip the config bootstrapping.
+ *
+ * @param string $configfile The relative path for config.php
+ * @return bool True if climaintenance.html is found.
+ */
+function check_climaintenance($configfile) {
+    $content = file_get_contents($configfile);
+
+    // Set comments to be on newlines, replace '//' with '\n//', where // does not start with a : colon.
+    $content = preg_replace("#[^!:]//#", "\n//", $content);
+    $content = preg_replace("/;/", ";\n", $content);         // Split up statements, replace ';' with ';\n'.
+    $content = preg_replace("/^[\s]+/m", "", $content);      // Removes all initial whitespace and newlines.
+
+    $re = '/^\$CFG->dataroot\s+=\s+["\'](.*?)["\'];/m';  // Lines starting with $CFG->dataroot.
+    preg_match($re, $content, $matches);
+    if (!empty($matches)) {
+        $climaintenance = $matches[count($matches) - 1] . '/climaintenance.html';
+
+        if (file_exists($climaintenance)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+if (check_climaintenance($dirroot . 'config.php') === true) {
+    print "CRITICAL: Moodle is in hard cli maintenance mode\n";
+    exit;
+}
+
 require_once($dirroot . 'config.php');
+
+if (!empty($CFG->maintenance_enabled)) {
+    print "CRITICAL: Moodle is in soft maintenance mode\n";
+    exit;
+}
 
 $filterids = [];
 if ($isweb) {

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025121604;
-$plugin->release   = 2025121604; // Match release exactly to version.
+$plugin->version   = 2025121605;
+$plugin->release   = 2025121605; // Match release exactly to version.
 $plugin->requires  = 2020061500; // Support for 3.9 and above, due to the Check API.
 $plugin->supported = [39, 405];
 $plugin->component = 'tool_heartbeat';


### PR DESCRIPTION
Closes #251

Right now if maint mode is on you get this meaningless summary:
```
<!DOCTYPE html>
```

This just gives nicer icinga compatible summary text. to test:

```
root@35538c8d0020:/var/www/main# php admin/cli/maintenance.php --enable
== Maintenance mode (https://main.localhost) ==
Your site is currently in Command Line Interface (CLI) maintenance mode. No web access is allowed.
root@35538c8d0020:/var/www/main# php admin/cli/maintenance.php --disable
== Maintenance mode (https://main.localhost) ==
Maintenance mode has been disabled and the site is running normally again
root@35538c8d0020:/var/www/main# php admin/cli/maintenance.php --enableold
== Maintenance mode (https://main.localhost) ==
Your site is currently in maintenance mode (only admins can log in or use the site).
```

while reloading https://main.localhost/admin/tool/heartbeat/croncheck.php